### PR TITLE
Bump ua-parser-js from 0.7.21 to 0.7.31

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -11877,9 +11877,9 @@ typescript@^3.2.2:
   integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
 
 ua-parser-js@^0.7.18:
-  version "0.7.21"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.21.tgz#853cf9ce93f642f67174273cc34565ae6f308777"
-  integrity sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ==
+  version "0.7.31"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.31.tgz#649a656b191dffab4f21d5e053e27ca17cbff5c6"
+  integrity sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ==
 
 undefsafe@^2.0.2:
   version "2.0.2"


### PR DESCRIPTION
### Description

In this pull request, the version of `ua-parser-js` is being updated from `0.7.21` to `0.7.31` in the `yarn.lock` file.

Changes:
- Updated `ua-parser-js` version from `0.7.21` to `0.7.31`
- Updated resolved URL and integrity hash for `ua-parser-js`

By updating the `ua-parser-js` version from `0.7.21` to `0.7.31`, we incorporate the latest changes and improvements provided by the newer version.