### PR TITLE
Update dependency @types/slick-carousel to v1.6.40

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@types/react-paginate": "6.2.1",
     "@types/react-router-dom": "5.1.3",
     "@types/react-slick": "0.23.4",
-    "@types/slick-carousel": "1.6.34",
+    "@types/slick-carousel": "1.6.40",
     "@types/styled-components": "4.4.3",
     "@types/uniqid": "5.2.0",
     "concurrently": "5.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1583,10 +1583,10 @@
   resolved "https://registry.yarnpkg.com/@types/sizzle/-/sizzle-2.3.2.tgz#a811b8c18e2babab7d542b3365887ae2e4d9de47"
   integrity sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg==
 
-"@types/slick-carousel@1.6.34":
-  version "1.6.34"
-  resolved "https://registry.yarnpkg.com/@types/slick-carousel/-/slick-carousel-1.6.34.tgz#ac8aa7c3175070baca9477c353724542a8ed74f7"
-  integrity sha512-LdsK0BLNYqe3uBuWCBwzGQVy+8g8LDe3u1XGlaOelrDD07cjJGVVoKBSyKieK4dmfqilmP+DJp7lNRaTI7rRAg==
+"@types/slick-carousel@1.6.40":
+  version "1.6.40"
+  resolved "https://registry.yarnpkg.com/@types/slick-carousel/-/slick-carousel-1.6.40.tgz#0d68ad5aced7980c8e2fe1d4563be94e129a7ec0"
+  integrity sha512-r56PBGVLYHmZvFSV+UC4dYbnpEu3LGzgJiSSixBx5ME+IUhsyho1XP7gKSG0R9tiYSx54ftq/g+miLQTbA10Dw==
   dependencies:
     "@types/jquery" "*"
 


### PR DESCRIPTION
### Description

In this pull request, the `@types/slick-carousel` package version has been updated from `1.6.34` to `1.6.40`.

**Changes:**
- Updated `@types/slick-carousel` package version from `1.6.34` to `1.6.40` in the `package.json` and `yarn.lock` files.