### PR TITLE
Update dependency @types/node to v14.18.63

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/history": "4.7.6",
     "@types/lodash": "4.14.158",
     "@types/moment": "2.13.0",
-    "@types/node": "14.0.24",
+    "@types/node": "14.18.63",
     "@types/react": "16.9.43",
     "@types/react-dom": "16.9.5",
     "@types/react-paginate": "6.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1485,10 +1485,15 @@
   dependencies:
     moment "*"
 
-"@types/node@*", "@types/node@14.0.24", "@types/node@>=6":
+"@types/node@*", "@types/node@>=6":
   version "14.0.24"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.24.tgz#b0f86f58564fa02a28b68f8b55d4cdec42e3b9d6"
   integrity sha512-btt/oNOiDWcSuI721MdL8VQGnjsKjlTMdrKyTcLCKeQp/n4AAMFJ961wMbp+09y8WuGPClDEv07RIItdXKIXAA==
+
+"@types/node@14.18.63":
+  version "14.18.63"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.63.tgz#1788fa8da838dbb5f9ea994b834278205db6ca2b"
+  integrity sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"


### PR DESCRIPTION
### Description

In this pull request, the version of `@types/node` in the package.json and yarn.lock files has been updated from `14.0.24` to `14.18.63`.

- Updated the version of `@types/node` in package.json from `"14.0.24"` to `"14.18.63"`.
- Updated the version of `@types/node` in yarn.lock from `14.0.24` to `14.18.63`.