### PR TITLE
Update dependency @types/lodash to v4.17.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@types/graphql": "14.5.0",
     "@types/history": "4.7.6",
-    "@types/lodash": "4.14.158",
+    "@types/lodash": "4.17.0",
     "@types/moment": "2.13.0",
     "@types/node": "14.0.24",
     "@types/react": "16.9.43",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1468,10 +1468,10 @@
     csstype "^2.0.0"
     indefinite-observable "^1.0.1"
 
-"@types/lodash@4.14.158":
-  version "4.14.158"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.158.tgz#b38ea8b6fe799acd076d7a8d7ab71c26ef77f785"
-  integrity sha512-InCEXJNTv/59yO4VSfuvNrZHt7eeNtWQEgnieIA+mIC+MOWM9arOWG2eQ8Vhk6NbOre6/BidiXhkZYeDY9U35w==
+"@types/lodash@4.17.0":
+  version "4.17.0"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.0.tgz#d774355e41f372d5350a4d0714abb48194a489c3"
+  integrity sha512-t7dhREVv6dbNj0q17X12j7yDG4bD/DHYX7o5/DbDxobP0HnGPgpRz2Ej77aL7TZT3DSw13fqUTj8J4mMnqa7WA==
 
 "@types/minimatch@*":
   version "3.0.3"


### PR DESCRIPTION
### Description

The changes in this pull request involve updating the version of `@types/lodash` in the `package.json` and `yarn.lock` files. 

- Update the version of `@types/lodash` from "4.14.158" to "4.17.0" in `package.json`.
- Update the version, resolved URL, and integrity for `@types/lodash` from "4.14.158" to "4.17.0" in the `yarn.lock` file.