### PR TITLE
[Security] Bump dot-prop from 4.2.0 to 4.2.1

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4257,9 +4257,9 @@ dot-case@^2.1.0:
     no-case "^2.2.0"
 
 dot-prop@^4.1.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-4.2.0.tgz#1f19e0c2e1aa0e32797c49799f2837ac6af69c57"
-  integrity sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-4.2.1.tgz#45884194a71fc2cda71cbb4bceb3a4dd2f433ba4"
+  integrity sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==
   dependencies:
     is-obj "^1.0.0"
 


### PR DESCRIPTION
### Description

In this pull request, the `dot-prop` package within the `yarn.lock` file has been updated. The version has been bumped from `4.2.0` to `4.2.1`, and the package's integrity hash has been updated accordingly.

Changes:
- Updated `dot-prop` package from version `4.2.0` to `4.2.1`.
- Updated the resolved URL for the `dot-prop` package.
- Updated the integrity hash for the `dot-prop` package.