### PR TITLE
[Security] Bump ini from 1.3.5 to 1.3.8

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6120,9 +6120,9 @@ inherits@2.0.3:
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
 ini@^1.3.4, ini@^1.3.5, ini@~1.3.0:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
-  integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
+  integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
 inquirer@6.2.2:
   version "6.2.2"


### PR DESCRIPTION
### Description

The changes in this pull request are updating the version of the `ini` package in the `yarn.lock` file from `1.3.5` to `1.3.8`.

- Update `ini` package version from `1.3.5` to `1.3.8`
- Update the resolved URL for the `ini` package to the new version `1.3.8`
- Update the integrity hash for the `ini` package to match the new version