### PR TITLE
Update dependency react-fast-compare to v3.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lodash": "^4.17.15",
     "react": "16.13.1",
     "react-dom": "16.13.1",
-    "react-fast-compare": "3.0.1",
+    "react-fast-compare": "3.2.2",
     "react-paginate": "^6.3.2",
     "react-router-dom": "5.1.2",
     "react-router-transition": "2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9995,10 +9995,10 @@ react-event-listener@^0.6.2:
     prop-types "^15.6.0"
     warning "^4.0.1"
 
-react-fast-compare@3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.0.1.tgz#884d339ce1341aad22392e7a88664c71da48600e"
-  integrity sha512-C5vP0J644ofZGd54P8++O7AvrqMEbrGf8Ue0eAUJLJyw168dAX2aiYyX/zcY/eSNwO0IDjsKUaLE6n83D+TnEg==
+react-fast-compare@3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.2.tgz#929a97a532304ce9fee4bcae44234f1ce2c21d49"
+  integrity sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==
 
 react-is@^16.6.0, react-is@^16.6.3, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4:
   version "16.12.0"


### PR DESCRIPTION
### Description

In this pull request, the version of the "react-fast-compare" package is being updated from 3.0.1 to 3.2.2 in both the `package.json` and `yarn.lock` files.

Changes:
- Update the version of the "react-fast-compare" package from 3.0.1 to 3.2.2 in `package.json`.
- Update the version and corresponding integrity hash of the "react-fast-compare" package in the `yarn.lock` file.